### PR TITLE
Fix/get orders

### DIFF
--- a/src/TIClient.php
+++ b/src/TIClient.php
@@ -63,7 +63,7 @@ class TIClient
     /**
      *
      * @param string $token token from tinkoff.ru for specific site
-     * @param TISiteEnum $site site name (sandbox or real exchange)
+     * @param string $site site name (sandbox or real exchange), @see TISiteEnum constants
      * @param null $account
      * @throws TIException
      */

--- a/src/TIClient.php
+++ b/src/TIClient.php
@@ -546,7 +546,11 @@ class TIClient
     public function getOrders($orderIds = null)
     {
         $orders = [];
-        $response = $this->sendRequest("/orders", "GET");
+        $response = $this->sendRequest(
+            "/orders",
+            "GET",
+            ["brokerAccountId" => $this->brokerAccountId]
+        );
         foreach ($response->getPayload() as $order) {
             if ($orderIds === null || in_array($order->orderId, $orderIds)) {
                 $ord = new TIOrder(

--- a/src/TIPortfolio.php
+++ b/src/TIPortfolio.php
@@ -33,7 +33,7 @@ class TIPortfolio {
     
     /**
      * Get balance of currency
-     * @param TICurrencyEnum $currency
+     * @param string $currency @see TICurrencyEnum constants
      * @return double or false
      */
     public function getCurrencyBalance($currency)


### PR DESCRIPTION
Пара мелких правок:
1) В getOrders не передавался brokerAccountId и для ИИС не приходил список заявок. Список отдавался от основного счета по дефолту
https://tinkoffcreditsystems.github.io/invest-openapi/swagger-ui/#/orders/get_orders

2) Фикс типов в документации, иначе IDE (PHPStorn) подсвечивает неверные передаваемые типы. По факту передается строка, а было указано, что объект класса.